### PR TITLE
Feature/authorization

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -23,7 +23,7 @@ export class AuthGuard implements CanActivate {
       context.getClass(),
     ]);
     if (isPublic) {
-      return true;
+      return true; //to make public route we can use @Public() decorator
     }
 
     const request = context.switchToHttp().getRequest();
@@ -36,6 +36,7 @@ export class AuthGuard implements CanActivate {
         secret: process.env.SECRET,
       });
       request['user'] = payload;
+      console.log(request['user'], 'usrerbhjdb');
     } catch {
       throw new UnauthorizedException();
     }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
+import { RolesGuard } from 'src/common/guards/roles.guards';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { AuthGuard } from './auth.guard';
       provide: APP_GUARD,
       useClass: AuthGuard,
     },
+
     AuthService,
   ],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
     if (!isPasswordCorrect) {
       throw new UnauthorizedException('Invalid Credentials');
     }
-    const payload = { sub: user.user_id, email: user.email };
+    const payload = { email: user.email, role: user.role, sub: user.user_id };
     return {
       msg: 'login successfully',
       access_token: await this.jwtService.signAsync(payload),

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -14,15 +14,18 @@ import { UpdateCampaignDto } from './dto/update-campaign.dto';
 import { Roles } from 'src/common/decorators/roles.decorators';
 import { RolesGuard } from 'src/common/guards/roles.guards';
 import { UserRole } from 'src/users/dto/userRole.enum';
+import { User } from 'src/users/entities/user.entity';
 
 @Controller('campaigns')
 export class CampaignsController {
   constructor(private readonly campaignsService: CampaignsService) {}
-
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.admin, UserRole.organizer)
   @Post()
   create(@Body() createCampaignDto: CreateCampaignDto) {
     return this.campaignsService.create(createCampaignDto);
   }
+
   @Get()
   findAll() {
     return this.campaignsService.findAll();

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -1,7 +1,19 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
 import { CampaignsService } from './campaigns.service';
 import { CreateCampaignDto } from './dto/create-campaign.dto';
 import { UpdateCampaignDto } from './dto/update-campaign.dto';
+import { Roles } from 'src/common/decorators/roles.decorators';
+import { RolesGuard } from 'src/common/guards/roles.guards';
+import { UserRole } from 'src/users/dto/userRole.enum';
 
 @Controller('campaigns')
 export class CampaignsController {
@@ -11,7 +23,6 @@ export class CampaignsController {
   create(@Body() createCampaignDto: CreateCampaignDto) {
     return this.campaignsService.create(createCampaignDto);
   }
-
   @Get()
   findAll() {
     return this.campaignsService.findAll();
@@ -23,7 +34,10 @@ export class CampaignsController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateCampaignDto: UpdateCampaignDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updateCampaignDto: UpdateCampaignDto,
+  ) {
     return this.campaignsService.update(+id, updateCampaignDto);
   }
 

--- a/src/common/decorators/roles.decorators.ts
+++ b/src/common/decorators/roles.decorators.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from 'src/users/dto/userRole.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/guards/roles.guards.ts
+++ b/src/common/guards/roles.guards.ts
@@ -14,7 +14,6 @@ export class RolesGuard implements CanActivate {
     if (!requiredRoles) {
       return true;
     }
-
     const { user } = context.switchToHttp().getRequest();
     if (!Array.isArray(user.role)) {
       return requiredRoles.includes(user.role); // Single role case

--- a/src/common/guards/roles.guards.ts
+++ b/src/common/guards/roles.guards.ts
@@ -15,9 +15,6 @@ export class RolesGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
-    if (!Array.isArray(user.role)) {
-      return requiredRoles.includes(user.role); // Single role case
-    }
     return requiredRoles.some((role) => user.role.includes(role));
   }
 }

--- a/src/common/guards/roles.guards.ts
+++ b/src/common/guards/roles.guards.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from 'src/users/dto/userRole.enum';
+import { ROLES_KEY } from '../decorators/roles.decorators';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    if (!Array.isArray(user.role)) {
+      return requiredRoles.includes(user.role); // Single role case
+    }
+    return requiredRoles.some((role) => user.role.includes(role));
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -53,7 +53,6 @@ export class UsersService {
   async findByEmail(email: string): Promise<User> {
     return this.userRepository.findOne({
       where: { email },
-      select: ['email', 'password'],
     });
   }
 }


### PR DESCRIPTION
## PR Title: Add Role-based Access Control for Campaign Creation

### Summary:
This PR introduces role-based access control (RBAC) for the campaign creation endpoint. It ensures that only users with the roles `admin` or `organizer` can access the `create` method in the campaign controller.

### Changes:
1. **Role Decorator**:
   - Added a `Roles` decorator to allow specifying roles required for a route handler.
   - This decorator uses the `SetMetadata` function to store roles as metadata for the route.

2. **Roles Guard**:
   - Introduced a `RolesGuard` that implements the `CanActivate` interface to check if the current user's role matches the required roles specified in the route handler.
   - If no roles are specified for a route, the guard allows the request to pass through.

3. **Applied Guard and Roles Decorator**:
   - The `RolesGuard` is applied to the `create` method of the campaign controller to restrict access to users with the `admin` or `organizer` roles.

### Files Modified:
- `src/decorators/roles.decorators.ts`: Added the `Roles` decorator.
- `src/guards/roles.guard.ts`: Implemented the `RolesGuard` to check user roles.
- `src/campaigns/campaigns.controller.ts`: Added the `Roles` decorator and `RolesGuard` to the `create` method.

### Example Usage:
```typescript
@UseGuards(RolesGuard)
@Roles(UserRole.admin, UserRole.organizer)
@Post()
create(@Body() createCampaignDto: CreateCampaignDto) {
  return this.campaignsService.create(createCampaignDto);
}
